### PR TITLE
[fix] Start openvpn properly (instance of yunohost.conf)

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -92,4 +92,4 @@ fi
 
 # Let's go !
 sudo service nginx reload
-sudo service openvpn restart
+sudo systemctl start openvpn@yunohost.service


### PR DESCRIPTION
https://github.com/Kloadut/openvpn_ynh/issues/12
OpenVPN instance of yunohost config file doesn't start. It should be done using systemctl command (at least once). 